### PR TITLE
[ODP-749] Link text specifies legacy key management

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,6 +1,7 @@
 <header id="full">
   <h3>API Key</h3>
   <p class="view"><a class="{{ current }}" href="https://api.trade.gov/apps/store/">Get a <b>new</b> API Key</a></p>
+  <p class="view"><a class="{{ current }}" href="{{ site.webservices_baseurl }}">Manage your <b>legacy</b> API Key</a></p>
   <h3>Top APIs</h3>
   {% for link in site.left_nav_top_apis %}
     <p class="view"><a class="{{ current }}" href="{{ link.url }}">{{ link.text }}</a></p>


### PR DESCRIPTION
Replaces the link so users can still manage their legacy keys, and emphasizes the difference between the legacy and new keys.